### PR TITLE
Support publishing to a branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Options:
   --version  Show version number [boolean]
   --remote   Git remote, may be remote name or full URL to the repo [default: "origin"]
   --tag      Tag name to which src will be published, for example: v1.2.3 - by default uses version from package.json
+  --branch   Branch name to append this new release to - none by default
   --push     Push update to the git remote (pass --no-push to disable) [boolean] [default: "true"]
   --force    Override any existing tag on the remote as well as locally (git tag -f, git push -f) [boolean]
 

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const argv = yargs
   .describe('remote', 'Git remote, may be remote name or full URL to the repo')
   .default('remote', 'origin')
   .describe('tag', 'Tag name to which src will be published, for example: v1.2.3 - by default uses version from package.json')
+  .describe('branch', "Branch name to append this new release to - none by default")
   .describe('push', 'Push update to the git remote (pass --no-push to disable)')
   .describe('force', 'Override any existing tag on the remote as well as locally (git tag -f, git push -f)')
   .boolean('push')
@@ -22,6 +23,7 @@ const packageJson = require(path.join(process.cwd(), '/package.json'));
 
 publish({
   tag: argv.tag,
+  branch: argv.branch,
   name: packageJson.name,
   version: packageJson.version,
   push: argv.push && {


### PR DESCRIPTION
Fixes #5.

This allows passing `--branch <branchname>` to append the newly created commit to an existing branch.

To make this happen, I changed the code to use `git workdir`, to check out the branch in a second (temporary) directory without creating a new repo.

While at it I also made that `push` won’t break if the used tag has the same name as a branch, by explicitly pushing `refs/tags/${tag}` instead of just `tag`.

I hope I covered the failure cases; e.g. removing the worktree and tag and resetting the branch if publishing fails. It may be worth checking such scenarios.

Some error and success messages that are presented may deserve an update, I did not address this yet as possibly issue #6 (multiple tags), if incorporated too, may require changing those again. Likewise I did not yet provide a possibility to publish only to a branch without creating a tag.