### PR TITLE
Forwarding parameter to pack

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ function spawnNpmWithOutput(args, options) {
   });
 }
 
-async function packWithNpm({ sourceDir, targetDir, verbose }) {
-  const output = (await spawnNpmWithOutput(['pack', sourceDir], {
+async function packWithNpm({ packageSpec, targetDir, verbose }) {
+  const output = (await spawnNpmWithOutput(['pack', packageSpec], {
     cwd: targetDir,
     verbose
   })).trim().split(/\n/);
@@ -60,7 +60,7 @@ async function packWithNpm({ sourceDir, targetDir, verbose }) {
   }
 }
 
-async function publish({tag, branch, version, push, packOptions}, pack = packWithNpm) {
+async function publish({tag, branch, version, push, packageSpec, packOptions}, pack = packWithNpm) {
   if (!tag) {
     tag = `v${version}`;
   }
@@ -86,7 +86,7 @@ async function publish({tag, branch, version, push, packOptions}, pack = packWit
     }
 
     await pack(Object.assign({
-      sourceDir: process.cwd(),
+      packageSpec: packageSpec,
       targetDir: tmpDir,
     }, packOptions));
 

--- a/main.js
+++ b/main.js
@@ -12,41 +12,27 @@ const argv = yargs
   .describe('branch', "Branch name to append this new release to - none by default")
   .describe('push', 'Push update to the git remote (pass --no-push to disable)')
   .describe('force', 'Override any existing tag on the remote as well as locally (git tag -f, git push -f)')
+  .parserConfiguration({ 'populate--': true })
   .describe('--', 'All arguments after -- are passed to npm pack command')
   .boolean('push')
   .boolean('force')
   .default('push', 'true')
   .wrap(yargs.terminalWidth())
   .argv;
-  
+
 const path = require('path');
 const packageJson = require(path.join(process.cwd(), '/package.json'));
 
-// default pack options
-let packOptions = { verbose: true };
-
 // packageSpec is the first non-option token after `--`.
-// Remaining forwarded tokens are forwarded as packOptions.args.
-let packageSpec = process.cwd();
-const ddIndex = process.argv.indexOf('--');
+// Remaining forwarded tokens are forwarded.
+const forwarded = yargs(argv['--'] || [])
+  .default('verbose', 'true')
+  .wrap(yargs.terminalWidth())
+  .argv;
 
-if (ddIndex !== -1) {
-  const forwarded = process.argv.slice(ddIndex + 1);  
-  if (forwarded.length) {
-    // find first token that is not an option (doesn't start with '-')
-    const firstNonOption = forwarded.findIndex(tok => !tok.startsWith('-'));
-    if (firstNonOption !== -1) {
-      packageSpec = forwarded[firstNonOption];
-      // remove the packageSpec token from forwarded list
-      forwarded.splice(firstNonOption, 1);
-    }
-    if (forwarded.length) {
-      packOptions = Object.assign({}, packOptions, { args: forwarded });
-    }
-  }
-}
-console.log('Pack options:', packOptions);
- 
+const packageSpec = forwarded._.length > 0 ? forwarded._ : process.cwd();
+console.log('Using packageSpec:', packageSpec);
+
 publish({
   tag: argv.tag,
   branch: argv.branch,
@@ -58,7 +44,7 @@ publish({
   },
   packageSpec,
   packOptions: {
-    ...packOptions
+    ...forwarded
   }
 }).catch(err => {
   if (err.cmd) {

--- a/main.js
+++ b/main.js
@@ -12,15 +12,41 @@ const argv = yargs
   .describe('branch', "Branch name to append this new release to - none by default")
   .describe('push', 'Push update to the git remote (pass --no-push to disable)')
   .describe('force', 'Override any existing tag on the remote as well as locally (git tag -f, git push -f)')
+  .describe('--', 'All arguments after -- are passed to npm pack command')
   .boolean('push')
   .boolean('force')
   .default('push', 'true')
   .wrap(yargs.terminalWidth())
   .argv;
-
+  
 const path = require('path');
 const packageJson = require(path.join(process.cwd(), '/package.json'));
 
+// default pack options
+let packOptions = { verbose: true };
+
+// packageSpec is the first non-option token after `--`.
+// Remaining forwarded tokens are forwarded as packOptions.args.
+let packageSpec = process.cwd();
+const ddIndex = process.argv.indexOf('--');
+
+if (ddIndex !== -1) {
+  const forwarded = process.argv.slice(ddIndex + 1);  
+  if (forwarded.length) {
+    // find first token that is not an option (doesn't start with '-')
+    const firstNonOption = forwarded.findIndex(tok => !tok.startsWith('-'));
+    if (firstNonOption !== -1) {
+      packageSpec = forwarded[firstNonOption];
+      // remove the packageSpec token from forwarded list
+      forwarded.splice(firstNonOption, 1);
+    }
+    if (forwarded.length) {
+      packOptions = Object.assign({}, packOptions, { args: forwarded });
+    }
+  }
+}
+console.log('Pack options:', packOptions);
+ 
 publish({
   tag: argv.tag,
   branch: argv.branch,
@@ -30,8 +56,9 @@ publish({
     remote: argv.remote,
     force: argv.force,
   },
+  packageSpec,
   packOptions: {
-    verbose: true
+    ...packOptions
   }
 }).catch(err => {
   if (err.cmd) {


### PR DESCRIPTION
Added parameter:

- '--', 'All arguments after -- are passed to npm pack command'
- default is still process.cwd()
- -- ... will pack '...' lib project